### PR TITLE
set the default working directory to a sample simulation

### DIFF
--- a/LDAR_Sim/model_code/ldar_sim_main.py
+++ b/LDAR_Sim/model_code/ldar_sim_main.py
@@ -30,7 +30,8 @@ import gc
 
 # ------------------------------------------------------------------------------
 # -----------------------------Global parameters--------------------------------
-wd = "C:/Users/tarca/PycharmProjects/LDAR_Sim/Dev/test3/"
+wd = "../inputs_template/"
+wd = os.path.abspath (wd) + "/"
 program_list = ['P_ref', 'P_alt', 'P_alt2']  # Programs to compare; Position one should be the reference program (P_ref)
 
 # -----------------------------Set up programs----------------------------------


### PR DESCRIPTION
Set the default working directory to be relative for test simulation to make it run easier first time.

Plotnine needs a full absolute path to save plot images properly - so I've added conversion to absolute path instead of relative path.

Possibly different sim should be default, 'getting started' simulation?